### PR TITLE
use pure components to improve perf

### DIFF
--- a/src/components/CheckboxFacet.tsx
+++ b/src/components/CheckboxFacet.tsx
@@ -7,7 +7,7 @@ import * as Numeral from "numeral";
 
 export type State = {};
 
-class CheckboxFacet extends React.Component<PropsType, State> {
+class CheckboxFacet extends React.PureComponent<PropsType, State> {
     render() {
         const facet = this.props.facet as Store.CheckboxFacet;
         let css = objAssign({}, defaultCss, this.props.css);

--- a/src/components/ClearFiltersButton.tsx
+++ b/src/components/ClearFiltersButton.tsx
@@ -6,7 +6,7 @@ import { defaultCss } from "../utils/css";
 
 export type State = {};
 
-class ClearFiltersButton extends React.Component<PropsType, State> {
+class ClearFiltersButton extends React.PureComponent<PropsType, State> {
   render() {
     const { lastUpdated, onClear, hasSelectedFacets } = this.props;
     let css = objAssign({}, defaultCss, this.props.css);

--- a/src/components/Pager.tsx
+++ b/src/components/Pager.tsx
@@ -6,7 +6,7 @@ import { defaultCss } from "../utils/css";
 
 export type State = {};
 
-class Pager extends React.Component<PropsType, State> {
+class Pager extends React.PureComponent<PropsType, State> {
     render() {
         const { count, top, skip, loadedResultsCount, pageUp, pageDown, loadPage } = this.props;
         let css = objAssign({}, defaultCss, this.props.css);

--- a/src/components/RangeFacet.tsx
+++ b/src/components/RangeFacet.tsx
@@ -8,7 +8,7 @@ import * as Numeral from "numeral";
 
 export type State = {};
 
-class RangeFacet extends React.Component<PropsType, State> {
+class RangeFacet extends React.PureComponent<PropsType, State> {
     render() {
         const facet = this.props.facet as Store.RangeFacet;
         let css = objAssign({}, defaultCss, this.props.css);

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -5,7 +5,7 @@ import { defaultCss } from "../utils/css";
 
 export type State = {};
 
-class Results extends React.Component<PropsType, State> {
+class Results extends React.PureComponent<PropsType, State> {
     render() {
         const { results, template, skip, top, count } = this.props;
         let css = objAssign({}, defaultCss, this.props.css);

--- a/src/components/SearchBox.tsx
+++ b/src/components/SearchBox.tsx
@@ -6,7 +6,7 @@ import { defaultCss } from "../utils/css";
 
 export type State = {};
 
-class SearchBox extends React.Component<PropsType, State> {
+class SearchBox extends React.PureComponent<PropsType, State> {
     onInputChange(changeEvent: React.ChangeEvent<HTMLInputElement>, newValue: any) {
         if (newValue.method === "up" || newValue.method === "down") {
             return;

--- a/src/components/SortBy.tsx
+++ b/src/components/SortBy.tsx
@@ -6,7 +6,7 @@ import { defaultCss } from "../utils/css";
 
 export type State = {};
 
-class SortBy extends React.Component<PropsType, State> {
+class SortBy extends React.PureComponent<PropsType, State> {
   render() {
     const { fields, defaultFieldName, lastUpdated, onSortChange } = this.props;
     let css = objAssign({}, defaultCss, this.props.css);


### PR DESCRIPTION
Pure components assume that when data props change, a shallow comparison can be used to compare equality. Since we're using redux and not mutating state (all updates are done through objectAssign), we can take advantage of this perf optimization.